### PR TITLE
feat: cadastro de dependente

### DIFF
--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
@@ -6,7 +6,6 @@ import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDepe
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroPrincipalRequest;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.response.CadastroUsuarioResponse;
 import tech.ada.bootcamp.arquitetura.cartaoservice.presenters.CriarCartaoPresenter;
-import tech.ada.bootcamp.arquitetura.cartaoservice.services.CartaoService;
 
 @RestController
 @RequestMapping("/usuario")

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
@@ -5,27 +5,25 @@ import org.springframework.web.bind.annotation.*;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDependenteRequest;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroPrincipalRequest;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.response.CadastroUsuarioResponse;
+import tech.ada.bootcamp.arquitetura.cartaoservice.presenters.CriarCartaoPresenter;
 import tech.ada.bootcamp.arquitetura.cartaoservice.services.CartaoService;
-
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/usuario")
 @Slf4j
 public class UsuarioController {
-    private CartaoService cartaoService;
-    public UsuarioController (CartaoService cartaoService) {
-        this.cartaoService = cartaoService;
+    private CriarCartaoPresenter cartaoPresenter;
+    public UsuarioController (CriarCartaoPresenter cartaoPresenter) {
+        this.cartaoPresenter = cartaoPresenter;
     }
     @PostMapping(path = "", produces = "application/json" )
     public CadastroUsuarioResponse cadastrarUsuario(@RequestBody CadastroPrincipalRequest dto){
-        return this.cartaoService.executeTitular(dto);
+        return this.cartaoPresenter.execute(dto);
     }
 
     @PostMapping(path = "/dependente", produces = "application/json" )
     public CadastroUsuarioResponse adicionarDependente(@RequestBody CadastroDependenteRequest dto){
-        return this.cartaoService.executeDependente(dto);
+        return this.cartaoPresenter.execute(dto);
     }
 
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
@@ -1,5 +1,6 @@
 package tech.ada.bootcamp.arquitetura.cartaoservice.controllers;
 
+import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDependenteRequest;
@@ -16,12 +17,12 @@ public class UsuarioController {
         this.cartaoPresenter = cartaoPresenter;
     }
     @PostMapping(path = "", produces = "application/json" )
-    public CadastroUsuarioResponse cadastrarUsuario(@RequestBody CadastroPrincipalRequest dto){
+    public CadastroUsuarioResponse cadastrarUsuario(@RequestBody @Valid CadastroPrincipalRequest dto){
         return this.cartaoPresenter.execute(dto);
     }
 
     @PostMapping(path = "/dependente", produces = "application/json" )
-    public CadastroUsuarioResponse adicionarDependente(@RequestBody CadastroDependenteRequest dto){
+    public CadastroUsuarioResponse adicionarDependente(@RequestBody @Valid CadastroDependenteRequest dto){
         return this.cartaoPresenter.execute(dto);
     }
 

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/UsuarioController.java
@@ -19,13 +19,13 @@ public class UsuarioController {
         this.cartaoService = cartaoService;
     }
     @PostMapping(path = "", produces = "application/json" )
-    public List<CadastroUsuarioResponse> cadastrarUsuario(@RequestBody CadastroPrincipalRequest dto){
-        return this.cartaoService.execute(dto);
+    public CadastroUsuarioResponse cadastrarUsuario(@RequestBody CadastroPrincipalRequest dto){
+        return this.cartaoService.executeTitular(dto);
     }
 
-    @PostMapping(path = "/dependente/{idUsuario}", produces = "application/json" )
-    public void adicionarDependente(@RequestBody CadastroDependenteRequest dto, @PathVariable("idUsuario") String idUsuario){
-
+    @PostMapping(path = "/dependente", produces = "application/json" )
+    public CadastroUsuarioResponse adicionarDependente(@RequestBody CadastroDependenteRequest dto){
+        return this.cartaoService.executeDependente(dto);
     }
 
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/VerFaturaController.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/controllers/VerFaturaController.java
@@ -2,8 +2,6 @@ package tech.ada.bootcamp.arquitetura.cartaoservice.controllers;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.*;
-import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroUsuarioRequest;
-import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.response.CadastroUsuarioResponse;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.response.FaturaResponse;
 
 @RestController

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Dependente.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Dependente.java
@@ -1,8 +1,6 @@
 package tech.ada.bootcamp.arquitetura.cartaoservice.entities;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDependenteRequest;
@@ -18,9 +16,13 @@ public class Dependente extends Usuario{
     @Id
     private String identificador;
     private String nome;
+    @ManyToOne
+    @JoinColumn(name = "principal_identificador")
+    private Principal principal;
 
-    public Dependente(CadastroDependenteRequest dto) {
+    public Dependente(CadastroDependenteRequest dto, Principal principal) {
         this.identificador = dto.identificador();
         this.nome = dto.nome();
+        this.principal = principal;
     }
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Dependente.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Dependente.java
@@ -4,9 +4,6 @@ import jakarta.persistence.*;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDependenteRequest;
-import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroUsuarioRequest;
-
-import java.util.Set;
 
 @Data
 @Entity

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Principal.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Principal.java
@@ -6,9 +6,6 @@ import jakarta.persistence.Table;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroPrincipalRequest;
-import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroUsuarioRequest;
-
-import java.util.Set;
 
 @Data
 @Entity

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Usuario.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/entities/Usuario.java
@@ -1,14 +1,5 @@
 package tech.ada.bootcamp.arquitetura.cartaoservice.entities;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
-import lombok.Data;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroUsuarioRequest;
-
-import java.util.Set;
 
 public abstract class Usuario {
     public abstract String getNome();

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroDependenteRequest.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroDependenteRequest.java
@@ -1,8 +1,24 @@
 package tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
 
 import java.util.List;
 
-public record CadastroDependenteRequest (String identificador, String identificadorTitular, String nome, TipoCartao tipoCartao){
+public record CadastroDependenteRequest (
+
+        //@CPF
+        @NotBlank
+        @Pattern(regexp = "^\\d{11}$")
+        String identificador,
+        @NotBlank
+        @Pattern(regexp = "^\\d{11}$")
+        //@CPF
+        String identificadorTitular,
+        @NotBlank
+        String nome,
+        @NotNull
+        TipoCartao tipoCartao){
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroDependenteRequest.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroDependenteRequest.java
@@ -4,5 +4,5 @@ import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
 
 import java.util.List;
 
-public record CadastroDependenteRequest (String identificador, String identificadorTitular, String nome, EnderecoRequest endereco, TipoCartao tipoCartao, List<String> dependentes){
+public record CadastroDependenteRequest (String identificador, String identificadorTitular, String nome, TipoCartao tipoCartao){
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroPrincipalRequest.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroPrincipalRequest.java
@@ -4,5 +4,5 @@ import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
 
 import java.util.List;
 
-public record CadastroPrincipalRequest (String identificador, String nome, EnderecoRequest endereco, TipoCartao tipoCartao, List<String> dependentes){
+public record CadastroPrincipalRequest (String identificador, String nome, EnderecoRequest endereco, TipoCartao tipoCartao){
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroPrincipalRequest.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroPrincipalRequest.java
@@ -1,8 +1,26 @@
 package tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import org.hibernate.validator.constraints.br.CPF;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
 
 import java.util.List;
 
-public record CadastroPrincipalRequest (String identificador, String nome, EnderecoRequest endereco, TipoCartao tipoCartao){
+public record CadastroPrincipalRequest (
+
+        //@CPF
+        @NotBlank
+        @Pattern(regexp = "^\\d{11}$")
+        String identificador,
+        @NotBlank
+        String nome,
+        @NotNull
+        @Valid
+        EnderecoRequest endereco,
+        @NotNull
+        TipoCartao tipoCartao){
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroUsuarioRequest.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/CadastroUsuarioRequest.java
@@ -1,8 +1,0 @@
-package tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request;
-
-import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
-
-import java.util.List;
-
-public record CadastroUsuarioRequest (String identificador, String nome, EnderecoRequest endereco, TipoCartao tipoCartao, List<String> dependentes){
-}

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/EnderecoRequest.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/payloads/request/EnderecoRequest.java
@@ -1,4 +1,21 @@
 package tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request;
 
-public record EnderecoRequest (String cep, String rua, String bairro, String cidade, String estado, String complemento, String numero) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record EnderecoRequest (
+        @NotBlank
+        @Pattern(regexp = "^\\d{8}$")
+        String cep,
+        @NotBlank
+        String rua,
+        @NotBlank
+        String bairro,
+        @NotBlank
+        String cidade,
+        @NotBlank
+        String estado,
+        String complemento,
+        @NotBlank
+        String numero) {
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/presenters/CriarCartaoPresenter.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/presenters/CriarCartaoPresenter.java
@@ -1,7 +1,13 @@
 package tech.ada.bootcamp.arquitetura.cartaoservice.presenters;
 
 import org.springframework.stereotype.Service;
+import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Dependente;
+import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Principal;
+import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDependenteRequest;
+import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroPrincipalRequest;
+import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.response.CadastroUsuarioResponse;
 import tech.ada.bootcamp.arquitetura.cartaoservice.repositories.CartaoRepository;
+import tech.ada.bootcamp.arquitetura.cartaoservice.services.CartaoService;
 import tech.ada.bootcamp.arquitetura.cartaoservice.services.UsuarioService;
 
 import java.time.LocalDate;
@@ -11,66 +17,21 @@ import java.util.stream.IntStream;
 @Service
 public class CriarCartaoPresenter {
     private UsuarioService usuarioService;
-    private CartaoRepository cartaoRepository;
-    private static Random random;
-
-    public CriarCartaoPresenter(UsuarioService usuarioService, CartaoRepository cartaoRepository) {
+    private CartaoService cartaoService;
+    public CriarCartaoPresenter(UsuarioService usuarioService, CartaoService cartaoService) {
         this.usuarioService = usuarioService;
-        this.cartaoRepository = cartaoRepository;
+        this.cartaoService = cartaoService;
     }
 
-/*
-    public List<CadastroUsuarioResponse> execute(CadastroDependenteRequest dto){
-        Usuario usuario = usuarioService.CriarNovoUsuario(dto);
-        List<CadastroUsuarioResponse> listaCartoesCadastrados = new ArrayList<CadastroUsuarioResponse>();
-
-        var cartao = criarCartao(usuario, dto.tipoCartao());
-        var cartaoCadastrado = cartaoRepository.save(cartao);
-        listaCartoesCadastrados.add(cartaoCadastrado.dto(usuario.getNome()));
-        usuarioService.AdicionarDependente(dto.identificadorContaPrincipal(), dto.identificador());
-        return listaCartoesCadastrados;
+    public CadastroUsuarioResponse execute(CadastroPrincipalRequest dto){
+        Principal titular = usuarioService.criarPrincipal(dto);
+        return cartaoService.cartaoTitular(titular, dto.tipoCartao());
     }
 
-    public List<CadastroUsuarioResponse> execute(CadastroPrincipalRequest dto){
-        Usuario usuario = usuarioService.CriarNovoUsuario(dto);
-        List<CadastroUsuarioResponse> listaCartoesCadastrados = new ArrayList<CadastroUsuarioResponse>();
-
-        var cartao = criarCartao(usuario, dto.tipoCartao());
-        var cartaoCadastrado = cartaoRepository.save(cartao);
-        listaCartoesCadastrados.add(cartaoCadastrado.dto(usuario.getNome()));
-
-        return listaCartoesCadastrados;
+    public CadastroUsuarioResponse execute(CadastroDependenteRequest dto){
+        Principal titular = usuarioService.getPrincipal(dto.identificadorTitular());
+        Dependente dependente = usuarioService.criarDependente(dto);
+        return cartaoService.cartaoDependente(dependente, titular, dto.tipoCartao());
     }
 
-
-
-    private Cartao criarCartao(Usuario usuario, TipoCartao tipoCartao) {
-        LocalDate dataAtual = LocalDate.now();
-        Cartao cartao = new Cartao();
-        cartao.setTipoCartao(tipoCartao);
-        cartao.setUsuario(usuario);
-        cartao.setIdContaBanco(UUID.randomUUID().toString());
-        cartao.setNomeTitular(usuario.getNome());
-        cartao.setVencimentoCartao(dataAtual.plusYears(5));
-        cartao.setCodigoSeguranca(gerarNumeroAleatorio(3));
-        cartao.setNumeroCartao(gerarNumeroAleatorio(12));
-        return cartao;
-    }
-
-    private String gerarNumeroAleatorio(int length) {
-
-        final int tamanho = length<=0?1:length;
-        IntStream stream =  getRandom().ints(tamanho,0,9);
-        StringBuilder builder = new StringBuilder();
-        stream.forEachOrdered(builder::append);
-        return builder.toString();
-    }
-
-    private static Random getRandom(){
-        if(Objects.isNull(random)){
-            random = new Random();
-        }
-        return random;
-    }
- */
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/repositories/EnderecoRepository.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/repositories/EnderecoRepository.java
@@ -4,6 +4,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Endereco;
 
+import java.util.Optional;
+
 @Repository
 public interface EnderecoRepository extends JpaRepository<Endereco, Long> {
+    Optional<Endereco> findByPrincipal (String principal);
 }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/CartaoService.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/CartaoService.java
@@ -27,25 +27,19 @@ public class CartaoService {
     }
 
 
-    public List<CadastroUsuarioResponse> execute(CadastroPrincipalRequest dto){
+    public CadastroUsuarioResponse executeTitular(CadastroPrincipalRequest dto){
         Principal titular = usuarioService.execute(dto);
-        List<CadastroUsuarioResponse> listaCartoesCadastrados = new ArrayList<CadastroUsuarioResponse>();
-
         var cartao = criarCartaoTitular(titular, dto.tipoCartao());
         var cartaoCadastrado = cartaoRepository.save(cartao);
-        listaCartoesCadastrados.add(cartaoCadastrado.dto(titular.getNome()));
-        return listaCartoesCadastrados;
+        return cartaoCadastrado.dto(titular.getNome());
     }
 
-    public List<CadastroUsuarioResponse> execute(CadastroDependenteRequest dtoDependente, CadastroPrincipalRequest dtoPrincipal){
-        Principal titular = usuarioService.execute(dtoPrincipal);
+    public CadastroUsuarioResponse executeDependente(CadastroDependenteRequest dtoDependente){
+        Principal titular = usuarioService.getPrincipal(dtoDependente.identificadorTitular());
         Dependente dependente = usuarioService.execute(dtoDependente);
-        List<CadastroUsuarioResponse> listaCartoesCadastrados = new ArrayList<CadastroUsuarioResponse>();
-
         var cartao = criarCartaoDependente(dependente, titular, dtoDependente.tipoCartao());
         var cartaoCadastrado = cartaoRepository.save(cartao);
-        listaCartoesCadastrados.add(cartaoCadastrado.dto(dependente.getNome()));
-        return listaCartoesCadastrados;
+        return cartaoCadastrado.dto(titular.getNome());
     }
 
 

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/CartaoService.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/CartaoService.java
@@ -4,7 +4,6 @@ import org.springframework.stereotype.Service;
 import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Cartao;
 import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Dependente;
 import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Principal;
-import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Usuario;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDependenteRequest;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroPrincipalRequest;
@@ -17,34 +16,29 @@ import java.util.stream.IntStream;
 
 @Service
 public class CartaoService {
-    private UsuarioService usuarioService;
     private CartaoRepository cartaoRepository;
     private static Random random;
 
-    public CartaoService(UsuarioService usuarioService, CartaoRepository cartaoRepository) {
-        this.usuarioService = usuarioService;
+    public CartaoService(CartaoRepository cartaoRepository) {
         this.cartaoRepository = cartaoRepository;
     }
 
 
-    public CadastroUsuarioResponse executeTitular(CadastroPrincipalRequest dto){
-        Principal titular = usuarioService.execute(dto);
-        var cartao = criarCartaoTitular(titular, dto.tipoCartao());
+    public CadastroUsuarioResponse cartaoTitular(Principal titular, TipoCartao tipoCartao){
+        var cartao = emitirCartaoTitular(titular, tipoCartao);
         var cartaoCadastrado = cartaoRepository.save(cartao);
         return cartaoCadastrado.dto(titular.getNome());
     }
 
-    public CadastroUsuarioResponse executeDependente(CadastroDependenteRequest dtoDependente){
-        Principal titular = usuarioService.getPrincipal(dtoDependente.identificadorTitular());
-        Dependente dependente = usuarioService.execute(dtoDependente);
-        var cartao = criarCartaoDependente(dependente, titular, dtoDependente.tipoCartao());
+    public CadastroUsuarioResponse cartaoDependente(Dependente dependente, Principal titular, TipoCartao tipoCartao){
+        var cartao = emitirCartaoDependente(dependente, titular, tipoCartao);
         var cartaoCadastrado = cartaoRepository.save(cartao);
         return cartaoCadastrado.dto(titular.getNome());
     }
 
 
 
-    private Cartao criarCartaoTitular(Principal principal, TipoCartao tipoCartao) {
+    private Cartao emitirCartaoTitular(Principal principal, TipoCartao tipoCartao) {
         LocalDate dataAtual = LocalDate.now();
         Cartao cartao = new Cartao();
         cartao.setTipoCartao(tipoCartao);
@@ -57,7 +51,7 @@ public class CartaoService {
         return cartao;
     }
 
-    private Cartao criarCartaoDependente(Dependente dependente, Principal principal, TipoCartao tipoCartao) {
+    private Cartao emitirCartaoDependente(Dependente dependente, Principal principal, TipoCartao tipoCartao) {
         LocalDate dataAtual = LocalDate.now();
         Cartao cartao = new Cartao();
         cartao.setTipoCartao(tipoCartao);

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/UsuarioService.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/UsuarioService.java
@@ -25,11 +25,12 @@ public class UsuarioService {
     }
 
     public Dependente execute(CadastroDependenteRequest dto) {
-        var principal = principalRepository.getReferenceById(dto.identificadorTitular());
-        var dependente = new Dependente(dto);
+        var principal = principalRepository.findById(dto.identificadorTitular());
+        if (principal.isEmpty()) {
+            //erro
+        }
+        var dependente = new Dependente(dto, principal.get());
         dependenteRepository.save(dependente);
-        var endereco = new Endereco(dto.endereco(), principal);
-        enderecoRepository.save(endereco);
         return dependente;
     }
 
@@ -41,6 +42,13 @@ public class UsuarioService {
         return principal;
     }
 
+    public Principal getPrincipal(String idTitular) {
+        var principalOp = principalRepository.findById(idTitular);
+        if(principalOp.isEmpty()) {
+            //Erro
+        }
+        return principalOp.get();
+    }
     public List<Principal> getAllPrincipal() {
         return principalRepository.findAll();
     }

--- a/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/UsuarioService.java
+++ b/src/main/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/UsuarioService.java
@@ -24,7 +24,7 @@ public class UsuarioService {
         this.enderecoRepository = enderecoRepository;
     }
 
-    public Dependente execute(CadastroDependenteRequest dto) {
+    public Dependente criarDependente(CadastroDependenteRequest dto) {
         var principal = principalRepository.findById(dto.identificadorTitular());
         if (principal.isEmpty()) {
             //erro
@@ -34,7 +34,7 @@ public class UsuarioService {
         return dependente;
     }
 
-    public Principal execute(CadastroPrincipalRequest  dto) {
+    public Principal criarPrincipal(CadastroPrincipalRequest  dto) {
         var principal = new Principal(dto);
         principalRepository.save(principal);
         var endereco = new Endereco(dto.endereco(), principal);

--- a/src/main/resources/db/ddl/init/002_create_table_dependente.xml
+++ b/src/main/resources/db/ddl/init/002_create_table_dependente.xml
@@ -21,6 +21,10 @@
             <column name="nome" type="character varying(255)">
                 <constraints nullable="false" />
             </column>
+            <column name="principal_identificador" type="character varying(255)">
+                <constraints foreignKeyName="fk_dependente_principal_identificador" referencedTableName="principal"
+                             referencedColumnNames="identificador" nullable="false" />
+            </column>
 
         </createTable>
     </changeSet>

--- a/src/test/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/CartaoServiceTest.java
+++ b/src/test/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/CartaoServiceTest.java
@@ -11,7 +11,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Cartao;
 import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
-import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroUsuarioRequest;
 import tech.ada.bootcamp.arquitetura.cartaoservice.repositories.CartaoRepository;
 
 import java.time.LocalDate;

--- a/src/test/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/UsuarioServiceTest.java
+++ b/src/test/java/tech/ada/bootcamp/arquitetura/cartaoservice/services/UsuarioServiceTest.java
@@ -1,0 +1,108 @@
+package tech.ada.bootcamp.arquitetura.cartaoservice.services;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Dependente;
+import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Endereco;
+import tech.ada.bootcamp.arquitetura.cartaoservice.entities.Principal;
+import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.TipoCartao;
+import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroDependenteRequest;
+import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.CadastroPrincipalRequest;
+import tech.ada.bootcamp.arquitetura.cartaoservice.payloads.request.EnderecoRequest;
+import tech.ada.bootcamp.arquitetura.cartaoservice.repositories.DependenteRepository;
+import tech.ada.bootcamp.arquitetura.cartaoservice.repositories.EnderecoRepository;
+import tech.ada.bootcamp.arquitetura.cartaoservice.repositories.PrincipalRepository;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UsuarioServiceTest {
+    @InjectMocks
+    private UsuarioService service;
+    @Mock
+    private PrincipalRepository principalRepository;
+    @Mock
+    private DependenteRepository dependenteRepository;
+    @Mock
+    private EnderecoRepository enderecoRepository;
+
+    private CadastroPrincipalRequest principalDto;
+    private CadastroDependenteRequest dependenteDto;
+    private Principal principal;
+    private Dependente dependente;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        iniciarTesteUsuario();
+    }
+
+    @Test
+    void criarDependente() {
+        when(principalRepository.findById(anyString())).thenReturn(Optional.of(principal));
+        service.criarDependente(dependenteDto);
+
+        verify(principalRepository, times(1)).findById(principal.getIdentificador());
+
+        ArgumentCaptor<Dependente> dependenteArgumentCaptor = ArgumentCaptor.forClass(Dependente.class);
+        verify(dependenteRepository, times(1))
+                .save(dependenteArgumentCaptor.capture());
+        Dependente dependenteSalvo = dependenteArgumentCaptor.getValue();
+        assertEquals("11111111111", dependenteSalvo.getIdentificador());
+        assertEquals("00000000000", dependenteSalvo.getPrincipal().getIdentificador());
+        assertEquals("Testador Dependente", dependenteSalvo.getNome());
+    }
+
+    @Test
+    void criarPrincipal() {
+        service.criarPrincipal(principalDto);
+
+        ArgumentCaptor<Principal> principalArgumentCaptor = ArgumentCaptor.forClass(Principal.class);
+        verify(principalRepository, times(1))
+                .save(principalArgumentCaptor.capture());
+        Principal titularSalvo = principalArgumentCaptor.getValue();
+
+        ArgumentCaptor<Endereco> enderecoArgumentCaptor = ArgumentCaptor.forClass(Endereco.class);
+        verify(enderecoRepository, times(1))
+                .save(enderecoArgumentCaptor.capture());
+        Endereco enderecoSalvo = enderecoArgumentCaptor.getValue();
+
+        assertEquals("00000000000", titularSalvo.getIdentificador());
+        assertEquals("Testador", titularSalvo.getNome());
+        assertEquals("00000000000", enderecoSalvo.getPrincipal().getIdentificador());
+        assertEquals("00000000", enderecoSalvo.getCep());
+        assertEquals("cidade1", enderecoSalvo.getCidade());
+    }
+
+    @Test
+    void getPrincipal() {
+
+    }
+
+    @Test
+    void getAllPrincipal() {
+
+    }
+
+    @Test
+    void getAllDependente() {
+
+    }
+
+    private void iniciarTesteUsuario() {
+        var endereco = new EnderecoRequest("00000000", "rua1", "bairro1", "cidade1", "estado1", "complemento1", "11");
+        this.principalDto = new CadastroPrincipalRequest("00000000000", "Testador", endereco, TipoCartao.PLATINA);
+        this.dependenteDto = new CadastroDependenteRequest("11111111111", "00000000000", "Testador Dependente", TipoCartao.OURO);
+        this.principal = new Principal(principalDto);
+        this.dependente = new Dependente(dependenteDto, principal);
+    }
+}


### PR DESCRIPTION
Cenário atual: 
* EndPoint POST "/": cadastro de titular e emissão de cartão (em conjunto) funcionando (sem validações de erros e dados). Não possibilita mais cadastrar dependentes em conjunto.
* EndPoint POST "/dependente": cadastro de dependente e emissão de cartão (em conjunto) funcionando (sem validações de erros e dados).